### PR TITLE
Replace deprecated optimist with yargs

### DIFF
--- a/lib/balena-lint.ts
+++ b/lib/balena-lint.ts
@@ -2,7 +2,7 @@ import { Options as PrettierOptions } from 'prettier';
 
 import { promises as fs } from 'fs';
 import * as glob from 'glob';
-import * as optimist from 'optimist';
+import yargs from 'yargs';
 import * as path from 'path';
 import * as tslint from 'tslint';
 import { promisify } from 'util';
@@ -253,26 +253,47 @@ const runLint = async function (
 };
 
 export const lint = async (passedParams: any) => {
-	const options = optimist(passedParams)
+	const options = yargs(passedParams)
 		.usage('Usage: balena-lint [options] [...]')
-		.describe(
-			'f',
-			'Specify a linting config file to extend and override balena-lint rules',
-		)
-		.describe('p', 'Print default balena-lint linting rules')
-		.describe(
-			'i',
-			'Ignore linting config files in project directory and its parents',
-		)
-		.describe('e', 'Override extensions to check, eg "-e js -e jsx"')
-		.boolean('typescript', 'Lint typescript files instead of coffeescript')
-		.boolean('fix', 'Attempt to automatically fix lint errors')
-		.boolean('no-prettier', 'Disables the prettier code format checks')
-		.boolean(
-			'tests',
-			'Treat input files as test sources to perform extra relevant checks',
-		)
-		.boolean('u', 'Run unused import check');
+		.option('f', {
+			describe:
+				'Specify a linting config file to extend and override balena-lint rules',
+			type: 'string',
+		})
+		.option('p', {
+			describe: 'Print default balena-lint linting rules',
+			type: 'boolean',
+		})
+		.option('i', {
+			describe:
+				'Ignore linting config files in project directory and its parents',
+			type: 'boolean',
+		})
+		.option('e', {
+			describe: 'Override extensions to check, eg "-e js -e jsx"',
+			type: 'string',
+		})
+		.option('typescript', {
+			describe: 'Lint typescript files instead of coffeescript',
+			type: 'boolean',
+		})
+		.option('fix', {
+			describe: 'Attempt to automatically fix lint errors',
+			type: 'boolean',
+		})
+		.option('no-prettier', {
+			describe: 'Disables the prettier code format checks',
+			type: 'boolean',
+		})
+		.option('tests', {
+			describe:
+				'Treat input files as test sources to perform extra relevant checks',
+			type: 'boolean',
+		})
+		.options('u', {
+			describe: 'Run unused import check',
+			type: 'boolean',
+		});
 
 	if (options.argv._.length < 1 && !options.argv.p) {
 		options.showHelp();
@@ -308,10 +329,9 @@ export const lint = async (passedParams: any) => {
 	}
 
 	let configOverridePath;
-	// optimist converts all --no-xyz args to a argv.xyz === false
-	const prettierCheck = options.argv.prettier !== false;
-	const testsCheck = options.argv.tests === true;
-	const typescriptCheck = options.argv.typescript;
+	const prettierCheck = options.argv.prettier === false ? false : true;
+	const testsCheck = options.argv.tests ? true : false;
+	const typescriptCheck = options.argv.typescript ? true : false;
 	const autoFix = options.argv.fix === true;
 	const lintConfiguration = typescriptCheck
 		? prettierCheck
@@ -363,7 +383,9 @@ export const lint = async (passedParams: any) => {
 		}
 	}
 
-	const paths = options.argv._;
+	const paths: string[] = options.argv._.map((element: any) => {
+		return element.toString();
+	});
 
 	lintConfiguration.prettierCheck = prettierCheck;
 	lintConfiguration.testsCheck = testsCheck;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@types/glob": "^7.1.3",
     "@types/lodash": "^4.14.167",
     "@types/node": "^10.17.51",
-    "@types/optimist": "0.0.29",
     "@types/prettier": "^2.1.6",
     "coffee-script": "^1.10.0",
     "coffeelint": "^1.15.0",
@@ -41,14 +40,15 @@
     "depcheck": "^1.3.1",
     "glob": "^7.1.6",
     "lodash": "^4.17.20",
-    "optimist": "^0.6.1",
     "prettier": "^2.2.1",
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",
     "tslint-no-unused-expression-chai": "^0.1.4",
-    "typescript": "^4.1.3"
+    "typescript": "^4.1.3",
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
+    "@types/yargs": "^16.0.0",
     "husky": "^4.3.7",
     "lint-staged": "^10.5.3",
     "require-npm4-to-publish": "^1.0.0"


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Replace deprecated `optimist` dependency with `yargs`, namely because `optimist` is no longer maintained and includes a version of `minimist` that has a vulnerability: https://github.com/advisories/GHSA-vh95-rmgr-6w4m.