### PR TITLE
patch: Change `.prettierrc` path to use scoped package structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ For prettier config create `.prettierrc.js`
 ```js
 const fs = require('fs');
 
-module.exports = JSON.parse(fs.readFileSync('./node_modules/balena-lint/config/.prettierrc', 'utf8'));
+module.exports = JSON.parse(fs.readFileSync('./node_modules/@balena/lint/config/.prettierrc', 'utf8'));
 ```
 
 Support


### PR DESCRIPTION
Since balena-lint is and should be installed as a scoped package with `npm i @balena/lint`. The path to the `prettierrc` file needed to be used also needs to change to represent the changes.