### PR TITLE
Include tsconfig settings in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "url": "git@github.com:balena-io-modules/node-balena-lint"
   },
   "files": [
+    "tsconfig.json",
     "bin/",
     "build/",
     "config/"


### PR DESCRIPTION
These tsconfig settings should form the base settings from which other repo's tsconfig files extend.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Running `npm pack` now results in the following files in the published bundle - note that tsconfig.json is now included:
```
npm notice === Tarball Contents === 
npm notice 68B   config/.prettierrc         
npm notice 154B  bin/balena-lint            
npm notice 9.7kB LICENSE                    
npm notice 1.8kB package.json               
npm notice 385B  tsconfig.json              
npm notice 67B   config/tslint-prettier.json
npm notice 727B  config/tslint.json         
npm notice 6.0kB CHANGELOG.md               
npm notice 3.0kB README.md       
```