### PR TITLE
Add '-t tsconfig.json' flag and 'no-floating-promises' rule

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,8 +1,8 @@
 {
 	"*.ts": [
-		"balena-lint --fix"
+		"node bin/balena-lint --fix"
 	],
 	"test/**/*.ts": [
-		"balena-lint --tests"
+		"node bin/balena-lint --tests"
 	]
 }

--- a/README.md
+++ b/README.md
@@ -71,16 +71,16 @@ Manually create these config files in your project root:
 ```json
 // if using prettier in your project
 {
-	"extends": [
-		"balena-lint/config/tslint-prettier.json"
-	]
+  "extends": [
+    "./node_modules/@balena/lint/config/tslint-prettier.json"
+  ]
 }
 
 // plain TypeScript
 {
-	"extends": [
-		"balena-lint/config/tslint.json"
-	]
+  "extends": [
+    "./node_modules/@balena/lint/config/tslint.json"
+  ]
 }
 ```
 
@@ -90,6 +90,26 @@ For prettier config create `.prettierrc.js`
 const fs = require('fs');
 
 module.exports = JSON.parse(fs.readFileSync('./node_modules/@balena/lint/config/.prettierrc', 'utf8'));
+```
+
+Rules that require type information
+-----------------------------------
+
+Some linting rules such as `no-floating-promises` require Typescript type information.
+To enable these rules, use the `-t` option to point to your project's `tsconfig.json`
+file, if any. Without the `-t` option, those rules will be disabled but may still print
+a warning message such as:  
+`Warning: The 'no-floating-promises' rule requires type information.`  
+To prevent this warning message from being printed, override the rules by creating a
+`tslint.json` file as described in the previous sections. For example:
+
+```json
+{
+    "extends": "./node_modules/@balena/lint/config/tslint-prettier.json",
+    "rules": {
+        "no-floating-promises": false
+    }
+}
 ```
 
 Support

--- a/config/tslint.json
+++ b/config/tslint.json
@@ -4,20 +4,21 @@
 		"tslint-no-unused-expression-chai"
 	],
 	"rules": {
+		"array-type": [true, "array-simple"],
+		"arrow-parens": false,
+		"ban-ts-ignore": true,
+		"curly": true,
 		"indent": [true, "tabs"],
+		"interface-name": false,
 		"jsdoc-format": true,
-		"whitespace": [false, "check-type"],
+		"max-classes-per-file": false,
+		"member-ordering": false,
+		"no-console": false,
+		"no-string-literal": false,
+		"no-var-requires": true,
 		"object-literal-sort-keys": false,
 		"only-arrow-functions": false,
 		"quotemark": [true, "single", "avoid-escape"],
-		"no-var-requires": true,
-		"arrow-parens": false,
-		"max-classes-per-file": false,
-		"ban-ts-ignore": true,
-		"no-console": false,
-		"no-string-literal": false,
-		"interface-name": false,
-		"member-ordering": false,
 		"variable-name": [
 			true,
 			"ban-keywords",
@@ -25,8 +26,7 @@
 			"allow-leading-underscore",
 			"allow-pascal-case"
 		],
-		"array-type": [true, "array-simple"],
-		"curly": true
+		"whitespace": [false, "check-type"]
 	},
 	"jsRules": true
 }

--- a/config/tslint.json
+++ b/config/tslint.json
@@ -14,6 +14,7 @@
 		"max-classes-per-file": false,
 		"member-ordering": false,
 		"no-console": false,
+		"no-floating-promises": true,
 		"no-string-literal": false,
 		"no-var-requires": true,
 		"object-literal-sort-keys": false,

--- a/lib/mocha-tests-lint.ts
+++ b/lib/mocha-tests-lint.ts
@@ -34,7 +34,7 @@ export async function lintMochaTests(
 	try {
 		await Promise.all(allCheckPromises);
 		return new MochaListResult(errorsFound ? message : 'OK', errorsFound);
-	} catch (e) {
+	} catch (e: any) {
 		console.error(e);
 		return new MochaListResult(`Error reading input files: ${e.message}`, true);
 	}

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
   ],
   "scripts": {
     "build": "tsc && npm run prettify && npm run lint",
-    "lint": "node ./bin/balena-lint lib/",
+    "lint": "node ./bin/balena-lint -t tsconfig.json lib/",
     "prepublish": "require-npm4-to-publish",
     "prepublishOnly": "npm run test",
-    "prettify": "node ./bin/balena-lint --fix lib/",
+    "prettify": "node ./bin/balena-lint -t tsconfig.json --fix lib/",
     "test": "npm run build && npm run test:typescript && npm run test:typescript-no-prettier",
     "test:typescript": "node ./bin/balena-lint test/typescript/prettier -i",
     "test:typescript-no-prettier": "node ./bin/balena-lint test/typescript/no-prettier -i --no-prettier"


### PR DESCRIPTION
Motivated by a "missing await clause" error caught by @srlowe in https://github.com/balena-io/balena-cli/pull/2378#discussion_r753178880

The [no-floating-promises](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-floating-promises.md) rule identifies situations where we may write:

```ts
doSomething();
```

When instead we should have written:

```ts
await doSomething();
```

It's smart enough not to bother us if we write:

```ts
doSomething().catch(reject);
```

I.e., it's happy as long as the promise is handled, even if there is no `await` keyword.

See proposed changes to README for additional information.

Tested alongside balena-cli PR balena-io/balena-cli/pull/2389, where 'no-floating-promises' actually caught a handful of issues.

Change-type: minor