### PR TITLE
Allow using void as a way to silence floating promise errors

### DIFF
--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -57,7 +57,10 @@ module.exports = {
 		"@typescript-eslint/no-empty-function": "error",
 		"@typescript-eslint/no-empty-interface": "error",
 		"@typescript-eslint/no-explicit-any": "off",
-		"@typescript-eslint/no-floating-promises": "error",
+		"@typescript-eslint/no-floating-promises": [
+			"error",
+			{ "ignoreVoid": true }
+		],
 		"@typescript-eslint/no-shadow": [
 			"error",
 			{


### PR DESCRIPTION
Change-type: patch
See: https://github.com/balena-io/pinejs/pull/682#discussion_r1308867996
See: https://github.com/typescript-eslint/typescript-eslint/issues/2569#issuecomment-692971631