### PR TITLE
Remove `@typescript-eslint/no-unnecessary-condition` from warnings

### DIFF
--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -167,7 +167,6 @@ module.exports = {
 		'@typescript-eslint/prefer-reduce-type-parameter': 'warn',
 		'@typescript-eslint/prefer-return-this-type': 'warn',
 		'@typescript-eslint/no-confusing-void-expression': 'warn',
-		'@typescript-eslint/no-unnecessary-condition': 'warn',
 		'@typescript-eslint/restrict-plus-operands': 'warn',
 
 		'@typescript-eslint/consistent-generic-constructors': 'warn',


### PR DESCRIPTION
It causes too many issues due to the pattern of `arr[n] == null` where it's assumed that indexing into an array will not give undefined but it potentially can

Change-type: patch