### PR TITLE
Update eslint to ~9.14.0 to avoid regression in typescript-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "Apache 2.0",
   "dependencies": {
-    "@eslint/js": "^9.10.0",
+    "@eslint/js": "~9.14.0",
     "@typescript-eslint/eslint-plugin": "^8.5.0",
     "@typescript-eslint/parser": "^8.5.0",
     "depcheck": "^1.4.7",
-    "eslint": "^9.10.0",
+    "eslint": "~9.14.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-chai-friendly": "^1.0.1",
     "eslint-plugin-jsdoc": "^50.2.2",


### PR DESCRIPTION
A fix is already merged in typescript-eslint
and available on the `canary` version,
but until it gets released we need this to
unblock master on packages that do not have
a package-lock (eg balena-sdk).

Change-type: patch
See: https://github.com/eslint/eslint/issues/19134
See: https://github.com/typescript-eslint/typescript-eslint/issues/10338