### PR TITLE
Set prettier eol config to auto

### DIFF
--- a/config/.prettierrc
+++ b/config/.prettierrc
@@ -1,5 +1,6 @@
 {
 	"singleQuote": true,
 	"trailingComma": "all",
-	"useTabs": true
+	"useTabs": true,
+	"endOfLine": "auto"
 }


### PR DESCRIPTION
This avoids annoying issues on windows when using autocrlf with git where prettier will complain a file has not been linted

Change-type: patch