### PR TITLE
Update typescript-eslint to 8.44.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   "dependencies": {
     "@eslint/js": "^9.21.0",
     "@tanstack/eslint-plugin-query": "^5.72.2",
-    "@typescript-eslint/eslint-plugin": "^8.26.0",
-    "@typescript-eslint/parser": "^8.26.0",
+    "@typescript-eslint/eslint-plugin": "^8.44.1",
+    "@typescript-eslint/parser": "^8.44.1",
     "depcheck": "^1.4.7",
     "eslint": "^9.21.0",
     "eslint-config-prettier": "^10.0.0",
@@ -52,7 +52,7 @@
     "globals": "^16.0.0",
     "prettier": "^3.5.3",
     "typescript": "^5.8.2",
-    "typescript-eslint": "^8.26.0",
+    "typescript-eslint": "^8.44.1",
     "yargs": "^17.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Explicitly bumps to a version that fixes issue https://github.com/typescript-eslint/typescript-eslint/issues/11609 
so that we can have an easy way to update in repos that we use balena-lint.

Change-type: patch
See: https://balena.fibery.io/Work/Project/We-should-migrate-from-lodash-to-es-toolkit-(UI-CLI-etc.)-1895